### PR TITLE
Apply alloy-rs ABI encoding methods refactoring

### DIFF
--- a/crates/uniswapx-rs/src/order.rs
+++ b/crates/uniswapx-rs/src/order.rs
@@ -48,11 +48,11 @@ pub fn decode_order(encoded_order: &str) -> Result<ExclusiveDutchOrder> {
     };
     let order_hex = hex::decode(encoded_order)?;
 
-    Ok(ExclusiveDutchOrder::decode_single(&order_hex, false)?)
+    Ok(ExclusiveDutchOrder::decode(&order_hex, false)?)
 }
 
 pub fn encode_order(order: &ExclusiveDutchOrder) -> Vec<u8> {
-    ExclusiveDutchOrder::encode_single(order)
+    ExclusiveDutchOrder::encode(order)
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
uniswap-rs doesn't build following [this refactoring](https://github.com/alloy-rs/core/commit/0c21fcc48eab0b52c20d3e98c739bac862aad8ff) in alloy-rs.