### PR TITLE
Apply Alloy abi encode functions refactoring (again)

### DIFF
--- a/crates/uniswapx-rs/src/order.rs
+++ b/crates/uniswapx-rs/src/order.rs
@@ -48,11 +48,11 @@ pub fn decode_order(encoded_order: &str) -> Result<ExclusiveDutchOrder> {
     };
     let order_hex = hex::decode(encoded_order)?;
 
-    Ok(ExclusiveDutchOrder::decode(&order_hex, false)?)
+    Ok(ExclusiveDutchOrder::abi_decode(&order_hex, false)?)
 }
 
 pub fn encode_order(order: &ExclusiveDutchOrder) -> Vec<u8> {
-    ExclusiveDutchOrder::encode(order)
+    ExclusiveDutchOrder::abi_encode(order)
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
So, looks like ABI encoding functions has been renamed again in Alloy! See [this commit](https://github.com/alloy-rs/core/commit/73e4e51ef4fccbdfb4ebf6c1e028430fdfbfc51a).

Wdyt of the idea to pin the `alloy` dependency to a given revision?

(And my commit is signed this time)